### PR TITLE
fix/improve package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "moosical",
   "version": "1.0.0",
   "description": "backend for moosical",
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,16 +2,15 @@
   "name": "moosical",
   "version": "1.0.0",
   "description": "backend for moosical",
+  "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",
-    "lint": "biome lint",
-    "format": "biome format",
-    "start": "node dist/index.js",
-    "reset-db": "npx prisma db push --force-reset && rm -rf covers",
+    "lint": "biome lint .",
+    "format": "biome format --write .",
+    "reset-db": "prisma db push --force-reset && rm -rf covers",
     "dev": "tsx --watch src/index.ts",
-    "docker": "npx prisma db push && npm start"
+    "docker": "prisma db push && npm start"
   },
   "author": "xiboon",
   "license": "MIT",
@@ -43,6 +42,5 @@
     "prisma": "^5.6.0",
     "sharp": "^0.33.2"
   },
-  "type": "module",
   "packageManager": "pnpm@8.15.4+sha256.cea6d0bdf2de3a0549582da3983c70c92ffc577ff4410cbf190817ddc35137c2"
 }


### PR DESCRIPTION
- pnpm start does exactly that by default its useless
- npx not needed its always used in that context + you would use pnpm exec instead if using pnpm
- fix biome scripts
- make the package private (it's not a library)

you should also move `prisma` to the dev dependencies as it's a cli tool meant as a dev dependency (source: prisma). can be fixed by running `pnpm add -D prisma`. i'm not doing that in the pr because that would involve me locally cloning the repo and running the command
![source](https://github.com/xiboon/moosical/assets/53496941/4b5e9819-55f7-4c56-a80b-21cdea59c5c2)
